### PR TITLE
Add mistake tooltips to scorecard

### DIFF
--- a/js/visualizations.js
+++ b/js/visualizations.js
@@ -84,12 +84,17 @@ const ModalManager = {
         }
 
         document.getElementById('feedback-message').innerHTML = message;
-        
+
         // Update competitor name in the modal
         if (typeof UIController !== 'undefined' && UIController.updateCompetitorName) {
             UIController.updateCompetitorName();
         }
-        
+
+        // Initialize tooltip behaviour for dynamic content
+        if (typeof UIController !== 'undefined' && UIController.initializeTooltipTriggers) {
+            UIController.initializeTooltipTriggers(document.getElementById('feedback-message'));
+        }
+
         this.show(this.modals.feedback);
     },
 


### PR DESCRIPTION
## Summary
- compute explanations within `analyzeExperiment`
- surface those reasons in UI through helper functions
- keep tooltips for wrong answers using the new reasons

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685881060b28832a8993b8ba6bc57e79