### PR TITLE
Add badge tracking and session summary display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1415,6 +1415,13 @@
                         </div>
                     </div>
 
+                    <!-- Badges Block -->
+                    <div class="bg-gray-800 rounded-lg p-6 mb-4" style="background-color: rgba(31, 41, 55, 0.8);">
+                        <h3 class="text-xl font-semibold text-white mb-4">Badges Earned</h3>
+                        <div id="final-badges" class="flex flex-wrap justify-center gap-2"></div>
+                        <p id="final-badges-empty" class="text-sm text-gray-400 text-center mt-2">Score a perfect challenge to start collecting badges.</p>
+                    </div>
+
                     <!-- Share Section -->
                     <div class="mb-4">
                         <p class="text-sm text-gray-400 mb-4">Share your achievement:</p>


### PR DESCRIPTION
## Summary
- add a badge catalog to challenge definitions and propagate badge metadata with each generated scenario
- track earned badges for perfect decisions, surface them in the feedback modal, and show the badge set in the completion summary
- update the completion modal with a dedicated badges panel for end-of-session visibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f669fba9bc832a8541683c8ad00c86