### PR TITLE
Improve onboarding guidance and in-app explanations

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,6 +440,31 @@
                     </p>
                 </div>
 
+                <div class="mt-10 max-w-3xl mx-auto bg-gray-900 bg-opacity-80 text-white p-6 rounded-2xl border shadow-xl"
+                    style="border-color: rgba(249, 115, 22, 0.4);">
+                    <h2 class="text-2xl font-semibold mb-4 text-orange-300">Quick rules</h2>
+                    <ol class="list-decimal list-inside space-y-2 text-gray-200 text-left">
+                        <li>Work through each experiment in order: judge if the data is trustworthy, pick the best
+                            decision, then choose the follow-up ritual.</li>
+                        <li>Your score is measured in conversions per day gained from shipping variants. Playing it safe
+                            keeps impact at 0, so look for trustworthy wins.</li>
+                        <li>Every three experiments make a round. Get 2 out of 3 right to advance and unlock harder
+                            scenarios.</li>
+                    </ol>
+                    <div class="mt-4 p-4 rounded-xl border border-gray-700 bg-gray-800 bg-opacity-70"
+                        style="background-color: rgba(31, 41, 55, 0.75);">
+                        <h3 class="text-lg font-semibold text-orange-200 mb-2">Opponent cheat sheet</h3>
+                        <ul class="space-y-1 text-sm text-gray-200">
+                            <li><strong>HiPPO</strong> – Follows gut feel. Great for spotting why opinions go wrong.</li>
+                            <li><strong>Random</strong> – Flips a coin. Baseline to beat.</li>
+                            <li><strong>Naive</strong> – Ships whatever looks highest today, ignores uncertainty.</li>
+                            <li><strong>Peek-a-boo</strong> – Keeps peeking and delaying until significance shows up.</li>
+                        </ul>
+                        <p class="mt-3 text-xs text-gray-300">Opponents are ordered from easiest to trickiest. The more
+                            disciplined you are, the bigger the gap you'll open.</p>
+                    </div>
+                </div>
+
             </div>
         </div>
 
@@ -638,19 +663,31 @@
                             <span id="accuracy" class="text-xl md:text-2xl font-bold score-value">0%</span>
                         </div>
                         <div>
-                            <span class="font-medium text-white">Your <span class="tooltip-trigger">Impact<span
-                                        class="tooltip-content">The incremental number of conversions per day as a
-                                        result of your decisions</span></span>: </span>
-                            <span id="user-impact" class="text-xl md:text-2xl font-bold score-value text-green-500">0
-                                cpd</span>
+                            <span
+                                class="tooltip-trigger inline-flex flex-wrap items-baseline gap-1 font-medium text-white">
+                                <span>Your Impact:</span>
+                                <span id="user-impact"
+                                    class="text-xl md:text-2xl font-bold score-value text-green-500">0 cpd</span>
+                                <span class="tooltip-content">
+                                    Impact measures the conversions per day you would add by shipping the variant right
+                                    now. Sticking with the base or keeping the test running keeps this at 0 because the
+                                    customer experience doesn't change. Use it to learn how confident calls translate
+                                    into business outcomes.
+                                </span>
+                            </span>
                         </div>
                         <div>
-                            <span class="font-medium text-white"><span id="competitor-name">Opponent</span> <span
-                                    class="tooltip-trigger">Impact<span class="tooltip-content">The incremental number
-                                        of conversions per day as a result of your opponent's decisions</span></span>:
+                            <span
+                                class="tooltip-trigger inline-flex flex-wrap items-baseline gap-1 font-medium text-white">
+                                <span><span id="competitor-name">Opponent</span> Impact:</span>
+                                <span id="opponent-impact"
+                                    class="text-xl md:text-2xl font-bold score-value text-red-500">0 cpd</span>
+                                <span class="tooltip-content">
+                                    Each opponent follows their own playbook when deciding whether to ship. Their impact
+                                    jumps when they roll out a variant— even if you pass—so you can see how reliable
+                                    your strategy is compared with theirs.
+                                </span>
                             </span>
-                            <span id="opponent-impact" class="text-xl md:text-2xl font-bold score-value text-red-500">0
-                                cpd</span>
                         </div>
                     </div>
                     <div class="flex items-center space-x-2">
@@ -738,7 +775,12 @@
                             <span class="font-medium text-white tooltip-trigger">
                                 What's your Follow Up?
                                 <span class="tooltip-content">
-                                    Choose next steps.
+                                    Choose what you'll do with the insight:
+                                    <br><strong>Celebrate</strong> – Ship the change and tell the story.
+                                    <br><strong>Iterate</strong> – Improve this idea before rolling out.
+                                    <br><strong>Validate</strong> – Double-check with QA, guardrail metrics, or a holdout.
+                                    <br><strong>Fix &amp; Rerun</strong> – Resolve data or setup issues, then restart the test.
+                                    <br><strong>None</strong> – Close this chapter and move on to a new hypothesis.
                                 </span>
                             </span>
                         </div>
@@ -758,6 +800,10 @@
                             <button type="button" name="follow_up" value="DO_NOTHING" class="decision-btn">
                                 None
                             </button>
+                        </div>
+                        <div class="mt-2 text-xs text-gray-300 text-center">
+                            Follow-up choices are about learning cadence&mdash;they won't change your score directly, but
+                            they'll teach you what great experiment hygiene looks like.
                         </div>
                     </div>
 
@@ -861,8 +907,8 @@
                             <span class="font-semibold text-gray-900">
                                 <span class="tooltip-trigger">No difference<span class="tooltip-content">We assume that
                                         there is no difference between the base and variant versions, and look for
-                                        evidence against it<br><a href="https://en.wikipedia.org/wiki/Null_hypothesis"
-                                            target="_blank" class="text-blue-500 hover:text-blue-700">Learn more
+                                        evidence against it.<br><a href="https://en.wikipedia.org/wiki/Null_hypothesis"
+                                            target="_blank" class="text-blue-500 hover:text-blue-700">Read on Wikipedia
                                             →</a></span></span>
                             </span>
                         </div>
@@ -870,9 +916,9 @@
                             <span class="font-medium text-gray-700">Experiment Type</span>
                             <span class="font-semibold text-gray-900">
                                 <span class="tooltip-trigger">2-sided Test<span class="tooltip-content">Tests for any
-                                        difference between variants, whether positive or negative<br><a
+                                        difference between variants, whether positive or negative.<br><a
                                             href="https://en.wikipedia.org/wiki/One-_and_two-tailed_tests"
-                                            target="_blank" class="text-blue-500 hover:text-blue-700">Learn more
+                                            target="_blank" class="text-blue-500 hover:text-blue-700">Read on Wikipedia
                                             →</a></span></span>
                             </span>
                         </div>
@@ -893,7 +939,7 @@
                                         significant. A lower value (e.g., 0.05) means we require stronger evidence
                                         to reject the null hypothesis.
                                         <a href="https://en.wikipedia.org/wiki/Statistical_significance" target="_blank"
-                                            class="text-blue-500 hover:text-blue-700">Learn more
+                                            class="text-blue-500 hover:text-blue-700">Read on Wikipedia
                                             →</a>
                                     </span>
                                 </span>
@@ -909,7 +955,7 @@
                                         higher power (e.g., 0.80) means we're more likely to detect meaningful
                                         differences between variants.
                                         <a href="https://en.wikipedia.org/wiki/Power_(statistics)" target="_blank"
-                                            class="text-blue-500 hover:text-blue-700">Learn more →</a>
+                                            class="text-blue-500 hover:text-blue-700">Read on Wikipedia →</a>
                                     </span>
                                 </span>
                             </span>
@@ -937,9 +983,9 @@
                             <span class="font-medium text-gray-700">
                                 <span class="tooltip-trigger">Minimum Relevant Effect<span class="tooltip-content">The
                                         smallest effect size (absolute) that would be considered practically meaningful
-                                        for your business<br><a href="https://en.wikipedia.org/wiki/Effect_size"
-                                            target="_blank" class="text-blue-500 hover:text-blue-700">Learn more
-                                            →</a></span></span>
+                                        for your business.<br><a href="https://en.wikipedia.org/wiki/Effect_size"
+                                            target="_blank" class="text-blue-500 hover:text-blue-700">Read on
+                                            Wikipedia →</a></span></span>
                             </span>
                             <span id="exp-min-effect" class="font-semibold text-gray-900"></span>
                         </div>
@@ -1095,6 +1141,12 @@
                                 </tr>
                             </tbody>
                         </table>
+                        <div class="mt-3 text-xs text-gray-600 leading-relaxed bg-yellow-50 border border-yellow-200 rounded-lg p-3">
+                            <strong>How to read these bars:</strong> the colored band marks the confidence interval for the
+                            lift. The thin line in the middle is the best estimate, while the light gray marker at 0% is
+                            "no change." If the band crosses 0% the result is still compatible with no impact, so tread
+                            carefully. When the entire bar sits on one side of 0%, the data supports a real movement.
+                        </div>
                     </div>
 
                     <div class="mt-0 p-3 bg-gray-50 rounded-lg">
@@ -1107,7 +1159,7 @@
                                         there is no real difference between variants. A p-value below the significance
                                         level (α) suggests the difference is statistically significant.
                                         <a href="https://en.wikipedia.org/wiki/P-value" target="_blank"
-                                            class="text-blue-500 hover:text-blue-700">Learn more →</a>
+                                            class="text-blue-500 hover:text-blue-700">Read on Wikipedia →</a>
                                     </span>
                                 </span>:
                             </span>

--- a/js/confidence-intervals.js
+++ b/js/confidence-intervals.js
@@ -175,7 +175,7 @@ function updateConfidenceIntervals(challenge) {
         
         // Add Twyman's Law alert if detected
         if (hasTwymansLaw) {
-            const message = `Twyman's Law detected: Suspiciously low p-value (p=${pValue.toFixed(10)}) and unusually large effect (more than 10 x the MRE)\n\n<a href=\"twymans-law.html\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-blue-500 hover:text-blue-700\">Learn more about Twyman's Law →</a>`;
+            const message = `Twyman's Law detected: Suspiciously low p-value (p=${pValue.toFixed(10)}) and unusually large effect (more than 10 x the MRE)\n\nWhy it matters: extreme wins often point to instrumentation problems. Pause and verify the data before acting.\n\n<a href=\"twymans-law.html\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-blue-500 hover:text-blue-700\">Twyman's Law explainer →</a>`;
             
             // Store the original text content
             const originalText = pValueElement.textContent;

--- a/js/ui-controller.js
+++ b/js/ui-controller.js
@@ -864,7 +864,7 @@ const UIController = {
         const baseRateCell = document.getElementById('base-rate');
         const { expected, actual, difference, pValue } = analysis.analysis.baseRate;
 
-        const message = `Design Base Rate: ${formatPercent(expected)}\nActual Base Rate: ${formatPercent(actual)}\nDifference: ${formatPercent(difference)}\np-value: ${pValue.toFixed(4)}\n\n<a href="base-rate-mismatch.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about base rate mismatches →</a>`;
+        const message = `Design Base Rate: ${formatPercent(expected)}\nActual Base Rate: ${formatPercent(actual)}\nDifference: ${formatPercent(difference)}\np-value: ${pValue.toFixed(4)}\n\nWhy it matters: we powered the test assuming ${formatPercent(expected)}. Starting from ${formatPercent(actual)} means the lift and power calculations are off, so treat wins with caution until you recalibrate.\n\n<a href="base-rate-mismatch.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Deep dive on base rate mismatches →</a>`;
         this.addWarningToCell(baseRateCell, message);
     },
 
@@ -891,13 +891,13 @@ const UIController = {
 
         // Check base variant
         if (actualBase < requiredSampleSize) {
-            const message = `Insufficient sample size (${actualBase.toLocaleString()} < ${requiredSampleSize.toLocaleString()})\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about sample size warnings →</a>`;
+            const message = `Insufficient sample size (${actualBase.toLocaleString()} < ${requiredSampleSize.toLocaleString()})\n\nWhy it matters: with fewer visitors than planned the test is underpowered. Extend the run or increase traffic before trusting a call.\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Sample size checklist →</a>`;
             this.addWarningToCell(document.getElementById('base-visitors'), message);
         }
 
         // Check variant
         if (actualVariant < requiredSampleSize) {
-            const message = `Insufficient sample size (${actualVariant.toLocaleString()} < ${requiredSampleSize.toLocaleString()})\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about sample size warnings →</a>`;
+            const message = `Insufficient sample size (${actualVariant.toLocaleString()} < ${requiredSampleSize.toLocaleString()})\n\nWhy it matters: with fewer visitors than planned the test is underpowered. Extend the run or increase traffic before trusting a call.\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Sample size checklist →</a>`;
             this.addWarningToCell(document.getElementById('variant-visitors'), message);
         }
 
@@ -907,7 +907,7 @@ const UIController = {
 
         if (totalVisitors < requiredTotal) {
             const completeTextElement = document.getElementById('exp-complete-text');
-            const message = `Runtime Complete but Insufficient sample size: ${totalVisitors.toLocaleString()} < ${requiredTotal.toLocaleString()}\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about sample size warnings →</a>`;
+            const message = `Runtime Complete but Insufficient sample size: ${totalVisitors.toLocaleString()} < ${requiredTotal.toLocaleString()}\n\nWhy it matters: even though time is up, traffic was light. Add more visitors or treat the outcome as exploratory only.\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Sample size checklist →</a>`;
 
             completeTextElement.textContent = '';
             completeTextElement.appendChild(this.createWarningIcon(message));
@@ -928,7 +928,7 @@ const UIController = {
         const visitorsHeader = document.querySelector('.metrics-table th:nth-child(2)');
         if (!visitorsHeader) return;
 
-        const message = `Sample Ratio Mismatch detected (p-value<0.0001)\n\n<a href="sample-ratio-mismatch.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about sample ratio mismatches →</a>`;
+        const message = `Sample Ratio Mismatch detected (p-value<0.0001)\n\nWhy it matters: traffic is not being split as planned, so one variant may be over/under represented. Investigate tracking, bucketing, or feature flags before trusting the lift.\n\n<a href="sample-ratio-mismatch.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Sample ratio mismatch guide →</a>`;
 
         visitorsHeader.textContent = '';
         visitorsHeader.appendChild(document.createTextNode('Visitors'));
@@ -966,7 +966,7 @@ const UIController = {
 
         const pValue = dataSource.simulation.pValue;
 
-        const message = `Twyman's Law detected: Suspiciously low p-value (p=${pValue.toFixed(10)}) and unusually large effect (more than 10 x the MRE)\n\n<a href="twymans-law.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about Twyman's Law →</a>`;
+        const message = `Twyman's Law detected: Suspiciously low p-value (p=${pValue.toFixed(10)}) and unusually large effect (more than 10 x the MRE)\n\nWhy it matters: extreme wins often mean a data bug, not a miracle. Double-check logging, audience filters, or experiment guardrails before celebrating.\n\n<a href="twymans-law.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Twyman's Law explainer →</a>`;
         // Use the proper warning cell helper function
         this.addWarningToCell(pValueElement, message);
     },
@@ -1014,7 +1014,7 @@ const UIController = {
             ? 'not significant'
             : 'n/a';
 
-        const message = `Lucky Day: Most of the total effect comes from ${dayLabel}.\nTotal effect after excluding it: ${effectPercentage}%, p-value: ${pValueText} (${significanceText})\n\n<a href="lucky-day-trap.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about lucky day traps →</a>`;
+        const message = `Lucky Day: Most of the total effect comes from ${dayLabel}.\nTotal effect after excluding it: ${effectPercentage}%, p-value: ${pValueText} (${significanceText})\n\nWhy it matters: a single outlier day is driving the win. Look for launch bugs, promos, or traffic spikes before trusting the lift.\n\n<a href="lucky-day-trap.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Lucky day trap explainer →</a>`;
 
         comparisonTab.appendChild(document.createTextNode(' '));
         const warningIcon = this.createWarningIcon(message, { type: 'lucky-day' });
@@ -1051,7 +1051,7 @@ const UIController = {
         const requiredSampleSize = originalExperiment?.experiment?.requiredSampleSizePerVariant || 0;
         const requiredTotalSampleSize = requiredSampleSize * 2;
         
-        const message = `Overdue Experiment: Planned for ${originalRuntime} days but ran for ${actualRuntime} days (${extraDays} extra days)\n\nSample Size:\n• Intended: ${requiredTotalSampleSize.toLocaleString()} total (${requiredSampleSize.toLocaleString()} per variant)\n• Actual: ${originalTotalVisitors.toLocaleString()} total (${originalBaseVisitors.toLocaleString()} base, ${originalVariantVisitors.toLocaleString()} variant)\n<a href="overdue-experiment.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about overdue experiments →</a>`;
+        const message = `Overdue Experiment: Planned for ${originalRuntime} days but ran for ${actualRuntime} days (${extraDays} extra days)\n\nSample Size:\n• Intended: ${requiredTotalSampleSize.toLocaleString()} total (${requiredSampleSize.toLocaleString()} per variant)\n• Actual: ${originalTotalVisitors.toLocaleString()} total (${originalBaseVisitors.toLocaleString()} base, ${originalVariantVisitors.toLocaleString()} variant)\n\nWhy it matters: running past plan can inflate false positives and wastes opportunity cost. Stop the test or reset expectations before interpreting the result.\n\n<a href="overdue-experiment.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Overdue experiment guide →</a>`;
 
         // Clear the element completely and rebuild it
         completeTextElement.innerHTML = '';
@@ -1123,7 +1123,7 @@ const UIController = {
 
         console.log('✅ Adding underpowered design alert!');
         
-        const message = `This sample size is not enough to reach the desired power of ${(underpoweredData.desiredPower * 100).toFixed(0)}% (power at this sample size is ${(underpoweredData.actualPower * 100).toFixed(0)}%)\n\nCorrect sample size to achieve ${(underpoweredData.desiredPower * 100).toFixed(0)}% power is  ${underpoweredData.correctSampleSize.toLocaleString()} per variant)\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about sample size calculations →</a>`;
+        const message = `This sample size is not enough to reach the desired power of ${(underpoweredData.desiredPower * 100).toFixed(0)}% (power at this sample size is ${(underpoweredData.actualPower * 100).toFixed(0)}%)\n\nCorrect sample size to achieve ${(underpoweredData.desiredPower * 100).toFixed(0)}% power is  ${underpoweredData.correctSampleSize.toLocaleString()} per variant)\n\nWhy it matters: without enough power you're likely to miss real improvements or chase noise. Re-plan the sample size or lower your minimum detectable effect.\n\n<a href="sample-size-warning.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Sample size calculator tips →</a>`;
 
         // Clear the element and rebuild it with warning icon
         sampleSizeElement.textContent = '';
@@ -1673,8 +1673,9 @@ const UIController = {
                     <span class="tooltip-trigger">
                         Conversion Rate ⚠️
                         <span class="tooltip-content">
-                            Data loss detected in experiment data
-                            <br><a href="data-loss-alert.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Learn more about data loss →</a>
+                            Data loss detected in experiment data. Missing events can flip the sign of a result—pause and
+                            investigate before you act.
+                            <br><a href="data-loss-alert.html" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:text-blue-700">Data loss troubleshooting →</a>
                         </span>
                     </span>
                 `;

--- a/styles.css
+++ b/styles.css
@@ -29,35 +29,39 @@ button:disabled {
     cursor: not-allowed;
 }
 
+
 .decision-btn {
     display: flex;
     align-items: center;
     justify-content: center;
     min-width: 6rem;
     height: 2.5rem;
-    background-color: #4a5568;
+    background-image: linear-gradient(135deg, #fdba74, #f97316);
     color: white;
     border: none;
     border-radius: 0.375rem;
     padding: 0.5rem 1rem;
     font-size: 0.875rem;
-    font-weight: 500;
+    font-weight: 600;
     cursor: pointer;
-    transition: background-color 0.2s, transform 0.1s;
+    transition: background-color 0.2s, transform 0.1s, box-shadow 0.2s, filter 0.2s;
     text-align: center;
     white-space: normal;
     word-wrap: break-word;
     line-height: 1.2;
+    box-shadow: 0 6px 14px rgba(249, 115, 22, 0.25);
 }
 
 .decision-btn.selected {
-    background-color: rgb(249, 115, 22);
+    background-image: linear-gradient(135deg, #f97316, #ea580c);
     opacity: 1 !important;
     transform: scale(1.05);
+    box-shadow: 0 8px 18px rgba(234, 88, 12, 0.35);
 }
 
 .decision-btn:hover {
     transform: scale(1.05);
+    filter: brightness(1.05);
 }
 
 .decision-btn:active {


### PR DESCRIPTION
## Summary
- add a quick rules panel, opponent cheat sheet, and richer impact tooltips so new players understand scoring and AI behavior
- restyle decision buttons and follow-up helper copy to feel clickable and explain each next-step choice
- expand in-app alerts with concise explanations plus optional deep-dive links and add a confidence-interval legend

## Testing
- Not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e83aa8858832abab62521c8e81950)